### PR TITLE
clarify how to pass values to ML routines in SYS

### DIFF
--- a/X16 Reference - 03 - BASIC.md
+++ b/X16 Reference - 03 - BASIC.md
@@ -20,8 +20,8 @@ The Commander X16 BASIC interpreter is 100% backwards-compatible with the Commod
 	* `CHR$(18)`: reverse
 	* `CHR$(14)`: switch to upper/lowercase font
 	* `CHR$(142)`: switch to uppercase/graphics font
-* The BASIC vector table ($0300-0$30B)
-* SYS arguments in RAM ($0300-$0312).
+* The BASIC vector table ($0300-0$30B, $0311/$0312)
+* SYS arguments in RAM ($030C-$030F).
 	* `$030C`: X Register
 	* `$030D`: Y Register
 	* `$030E`: Status Register/Flags

--- a/X16 Reference - 03 - BASIC.md
+++ b/X16 Reference - 03 - BASIC.md
@@ -20,7 +20,12 @@ The Commander X16 BASIC interpreter is 100% backwards-compatible with the Commod
 	* `CHR$(18)`: reverse
 	* `CHR$(14)`: switch to upper/lowercase font
 	* `CHR$(142)`: switch to uppercase/graphics font
-* The BASIC vector table and SYS arguments in RAM ($0300-$0312)
+* The BASIC vector table ($0300-0$30B)
+* SYS arguments in RAM ($0300-$0312).
+	* `$030C`: X Register
+	* `$030D`: Y Register
+	* `$030E`: Status Register/Flags
+	* `$030F`: Accumulator
 
 Because of the differences in hardware, the following functions and statements are incompatible between C64 and X16 BASIC programs.
 


### PR DESCRIPTION
I was unclear how to pre-load the CPU registers on the X16 when using the SYS command. I knew "there was a way" on the Commodore 64, but while it's a known thing, a lot of programming documentation just skipped right past it. 

This reflects my research of where the SYS command picks up and drops off the CPU registers. As this is super useful when accessing ML routines from BASIC, it's worth calling out in the documentation.
