### PR TITLE
Convert Kernal API reference to table format

### DIFF
--- a/X16 Reference - 04 - KERNAL.md
+++ b/X16 Reference - 04 - KERNAL.md
@@ -126,8 +126,8 @@ The 16 bit ABI generally follows the following conventions:
 | [`GRAPH_draw_rect`](#function-name-GRAPH_draw_rect) &#8224; | `$FF2F` | Video | Draw a rectangle (optionally filled) | r0 r1 r2 r3 r4 C | A P | X16
 | [`GRAPH_get_char_size`](#function-name-GRAPH_get_char_size) | `$FF3E` | Video | Get size and baseline of a character | A X | A X Y P | X16
 | [`GRAPH_init`](#function-name-GRAPH_init) | `$FF20` | Video | Initialize graphics | r0 | r0 r1 r2 r3 A X Y P | X16
-| [`GRAPH_move_rect`](#function-name-GRAPH_move_rect) | `$FF32` | Video | Move pixels | r0 r1 r2 r3 r4 r5 | r1 r3 r5 A X Y P | X16
-| [`GRAPH_put_char`](#function-name-GRAPH_put_char) | `$FF41` | Video | Print a character | r0 r1 A | r0 r1 A X Y P | X16
+| [`GRAPH_move_rect`](#function-name-GRAPH_move_rect) &#8224; | `$FF32` | Video | Move pixels | r0 r1 r2 r3 r4 r5 | r1 r3 r5 A X Y P | X16
+| [`GRAPH_put_char`](#function-name-GRAPH_put_char) &#8224;| `$FF41` | Video | Print a character | r0 r1 A | r0 r1 A X Y P | X16
 | [`GRAPH_set_colors`](#function-name-GRAPH_set_colors) | `$FF29` | Video | Set stroke, fill and background colors | A X Y | none | X16
 | [`GRAPH_set_font`](#function-name-GRAPH_set_font) | `$FF3B` | Video | Set the current font | r0 | r0 A Y P | X16
 | [`GRAPH_set_window`](#function-name-GRAPH_set_window) &#8224;| `$FF26` | Video | Set clipping region | r0 r1 r2 r3 | A P | X16
@@ -157,7 +157,7 @@ The 16 bit ABI generally follows the following conventions:
 | [`mouse_get`](#function-name-mouse_get) | `$FF6B` | Mouse | Get saved mouse sate | X | A (X) P | X16
 | [`mouse_scan`](#function-name-mouse_scan) | `$FF71` | Mouse | Poll mouse state and save it | none | A X Y P | X16
 | `OPEN` | `$FFC0` | ChIO | Open a channel | | | C64 |
-| `PFKEY` | `$FF65` | Kbd | Program a function key *[not yet implemented]* | | | C128 |
+| `PFKEY` &#128683; | `$FF65` | Kbd | Program a function key *[not yet implemented]* | | | C128 |
 | `PLOT` | `$FFF0` | Video | Read/write cursor position | | | C64 |
 | `PRIMM` | `$FF7D` | Misc | Print string following the caller’s code | | | C128 |
 | `RDTIM` | `$FFDE` | Time | Read system clock | | | C64 |

--- a/X16 Reference - 04 - KERNAL.md
+++ b/X16 Reference - 04 - KERNAL.md
@@ -20,6 +20,73 @@ The Commander X16 contains a version of KERNAL as its operating system in ROM. I
 	* Commodore Serial Bus ("IEC")
 	* I2C bus
 
+
+### KERNAL calls
+
+| Label | Address | Class | Description | Inputs | Affects | Origin |
+|-|-|-|-|-|-|-|
+| `SETMSG` | `$FF90` | ChIO | Set verbosity | | | C64 |
+| `READST` | `$FFB7` | ChIO | Return status byte | | | C64 |
+| `SETLFS` | `$FFBA` | ChIO | Set LA, FA, and SA | | | C64 |
+| `SETNAM` | `$FFBD` | ChIO | Set filename | | | C64 |
+| `OPEN` | `$FFC0` | ChIO | Open a channel | | | C64 |
+| `CLOSE` | `$FFC3` | ChIO | Close a channel | | | C64 |
+| `CHKIN` | `$FFC6` | ChIO | Set channel for character input | | | C64 |
+| `CLRCHN` | `$FFCC` | ChIO | Restore character I/O to screen/keyboard | | | C64 |
+| `BASIN` | `$FFCF` | ChIO | Get character | | | C64 |
+| `BSOUT` | `$FFD2` | ChIO | Write character | | | C64 |
+| `LOAD` | `$FFD5` | ChIO | Load a file into memory | | | C64 |
+| `SAVE` | `$FFD8` | ChIO | Save a file from memory | | | C64 |
+| `CLALL` | `$FFE7` | ChIO | Close all channels | | | C64 |
+| `TALK` | `$FFB4` | CPB | Send TALK command  | | | C64 |
+| `LISTEN` | `$FFB1` | CPB | Send LISTEN command | | | C64 |
+| `UNLSN` | `$FFAE` | CPB | Send UNLISTEN command | | | C64 |
+| `UNTLK` | `$FFAB` | CPB | Send UNTALK command | | | C64 |
+| `CIOUT` | `$FFA8` | CPB | Send byte to peripheral bus | | | C64 |  
+| `ACPTR` | `$FFA5` | CPB | Read byte from peripheral bus | | | C64 |
+| `SETTMO` | `$FFA2` | CPB | Set timeout | | | C64 |
+| `TKSA` | `$FF96` | CPB | Send TALK secondary address | | | C64 |
+| `SECOND` | `$FF93` | CPB | Send LISTEN secondary address | | | C64 |
+| `MEMBOT` | `$FF9C` | Mem | Get address of start of usable RAM | | | C64 |
+| `MEMTOP` | `$FF99` | Mem | Get address of end of usable RAM | | | C64 |
+| `RDTIM` | `$FFDE` | Time | Read system clock | | | C64 |
+| `SETTIM` | `$FFDB` | Time | Write system clock | | | C64 |
+| `UDTIM` | `$FFEA` | Time | Advance clock | | | C64 |
+| `STOP` | `$FFE1` | Kbd | Test for STOP key  | | | C64 |
+| `GETIN` | `$FFE4` | Kbd | Get character from keyboard | | | C64 |
+| `SCREEN` | `$FFED` | Video | Get the screen resolution  | | | C64 |
+| `PLOT` | `$FFF0` | Video | Read/write cursor position | | | C64 |
+| `IOBASE` | `$FFF3` | Misc | Return start of I/O area | | | C64 |
+| `CLOSE_ALL` | `$FF4A` | ChIO | Close all files on a device  | | | C128 |
+| `LKUPLA` | `$FF59` | ChIO | Search tables for given LA | | | C128 |
+| `LKUPSA` | `$FF5C` | ChIO | Search tables for given SA | | | C128 |
+| `PFKEY` | `$FF65` | Kbd | Program a function key *[not yet implemented]* | | | C128 |
+| `PRIMM` | `$FF7D` | Misc | Print string following the caller’s code | | | C128 |
+| `MACPTR` | `$FF44` | CPB | Read multiple bytes from the peripheral bus | A X Y C | A X Y P | X16
+| [`memory_fill`](#function-name-memory_fill) | `$FEE4` | Mem | Fill a memory region with a byte value | A r0 r1 | r1 X Y P | X16
+| [`memory_copy`](#function-name-memory_copy) | `$FEE7` | Mem | Copy a memory region to a different region | r0 r1 r2 | r2 A X Y P | X16
+| [`memory_crc`](#function-name-memory_crc) | `$FEEA` | Mem | Calculate the CRC16 of a memory region | r0 r1 | r2 A X Y P | X16
+| [`memory_decompress`](#function-name-memory_decompress) | `$FEED` | Mem | Decompress an LZSA2 block | r0 r1 | r1 A X Y P | X16
+| [`fetch`](#function-name-fetch) | `$FF74` | Mem | Read a byte from any RAM or ROM bank | (A) X Y | A X P | X16
+| [`stash`](#function-name-stash) | `$FF77` | Mem | Write a byte to any RAM bank | stavec A X Y | X P | X16
+| [`clock_set_date_time`](#function-name-clock_set_date_time) | `$FF4D` | Time | Set the date and time | r0 r1 r2 r3L | A X Y P | X16
+| [`clock_get_date_time`](#function-name-clock_get_date_time) | `$FF50` | Time | Get the date and time | none | r0 r1 r2 r3L A X Y P | X16
+| [`kbdbuf_peek`](#function-name-kbdbuf_peek) | `$FEBD` | Kbd | Get next char and keyboard queue length | A X | A X P | X16
+| [`kbdbuf_get_modifiers`](#function-name-kbdbuf_get_modifiers) | `$FEC0` | Kbd | Get currently pressed modifiers | A | A X P | X16
+| [`kbdbuf_put`](#function-name-kbdbuf_put) | `$FEC3` | Kbd | Append a character to the keyboard queue | A | X | X16
+| [`keymap`](#function-name-keymap) | `$FED2` | Kbd | Set or get the current keyboard layout Call address | X Y C | A X Y C | X16
+| [`mouse_config`](#function-name-mouse_config) | `$FF68` | Mouse | Configure mouse pointer | A X Y | A X Y P | X16
+| [`mouse_scan`](#function-name-mouse_scan) | `$FF71` | Mouse | Poll mouse state and save it | none | A X Y P | X16
+| [`mouse_get`](#function-name-mouse_get) | `$FF6B` | Mouse | Get saved mouse sate | (X) | A P | X16
+| [`joystick_scan`](#function-name-joystick_scan) | `$FF53` | Joy | Poll controller states and save them | none | A X Y P | X16
+| [`joystick_get`](#function-name-joystick_get) | `$FF56` | Joy | Get one of the saved controller states | A | A X Y P | X16
+| [`i2c_read_byte`](#function-name-i2c_read_byte) | `$FEC6` | I2C | Read a byte from an I2C device | A X Y | A C | X16
+| [`i2c_write_byte`](#function-name-i2c_write_byte) | `$FEC9` | I2C | Write a byte to an I2C device | A X Y | A C | X16
+
+
+
+
+
 ### KERNAL Version
 
 The KERNAL version can be read from location $FF80 in ROM. A value of $FF indicates a custom build. All other values encode the build number. Positive numbers are release versions ($02 = release version 2), two's complement negative numbers are prerelease versions ($FE = $100 - 2 = prerelease version 2).

--- a/X16 Reference - 04 - KERNAL.md
+++ b/X16 Reference - 04 - KERNAL.md
@@ -85,8 +85,8 @@ The 16 bit ABI generally follows the following conventions:
 
 | Label | Address | Class | Description | Inputs | Affects | Origin |
 |-|-|-|-|-|-|-|
-| `ACPTR` | `$FFA5` | [CPB](# "Commodore Peripheral Bus") | Read byte from peripheral bus | | | C64 |
-| `BASIN` | `$FFCF` | [ChIO](# "Channel I/O") | Get character | | | C64 |
+| `ACPTR` | `$FFA5` | [CPB](#kernal-api-functions "Commodore Peripheral Bus") | Read byte from peripheral bus | | | C64 |
+| `BASIN` | `$FFCF` | [ChIO](#kernal-api-functions "Channel I/O") | Get character | | | C64 |
 | `BSOUT` | `$FFD2` | ChIO | Write character | | | C64 |
 | `CIOUT` | `$FFA8` | CPB | Send byte to peripheral bus | | | C64 |  
 | `CLALL` | `$FFE7` | ChIO | Close all channels | | | C64 |
@@ -130,7 +130,7 @@ The 16 bit ABI generally follows the following conventions:
 | [`GRAPH_put_char`](#function-name-GRAPH_put_char) | `$FF41` | Video | Print a character | r0 r1 A | r0 r1 A X Y P | X16
 | [`GRAPH_set_colors`](#function-name-GRAPH_set_colors) | `$FF29` | Video | Set stroke, fill and background colors | A X Y | none | X16
 | [`GRAPH_set_font`](#function-name-GRAPH_set_font) | `$FF3B` | Video | Set the current font | r0 | r0 A Y P | X16
-| [`GRAPH_set_window`](#function-name-GRAPH_set_window) | `$FF26` | Video | Set clipping region | r0 r1 r2 r3 | A P | X16
+| [`GRAPH_set_window`](#function-name-GRAPH_set_window) &#8224;| `$FF26` | Video | Set clipping region | r0 r1 r2 r3 | A P | X16
 | [`i2c_read_byte`](#function-name-i2c_read_byte) | `$FEC6` | I2C | Read a byte from an I2C device | A X Y | A C | X16
 | [`i2c_write_byte`](#function-name-i2c_write_byte) | `$FEC9` | I2C | Write a byte to an I2C device | A X Y | A C | X16
 | `IOBASE` | `$FFF3` | Misc | Return start of I/O area | | | C64 |

--- a/X16 Reference - 04 - KERNAL.md
+++ b/X16 Reference - 04 - KERNAL.md
@@ -32,17 +32,70 @@ The Commander X16 contains a version of KERNAL as its operating system in ROM. I
 | `CLALL` | `$FFE7` | ChIO | Close all channels | | | C64 |
 | `CLOSE` | `$FFC3` | ChIO | Close a channel | | | C64 |
 | `CHKIN` | `$FFC6` | ChIO | Set channel for character input | | | C64 |
+| [`clock_get_date_time`](#function-name-clock_get_date_time) | `$FF50` | Time | Get the date and time | none | r0 r1 r2 r3L A X Y P | X16
+| [`clock_set_date_time`](#function-name-clock_set_date_time) | `$FF4D` | Time | Set the date and time | r0 r1 r2 r3L | A X Y P | X16
 | `CLOSE_ALL` | `$FF4A` | ChIO | Close all files on a device  | | | C128 |
 | `CLRCHN` | `$FFCC` | ChIO | Restore character I/O to screen/keyboard | | | C64 |
+| [`console_init`](#function-name-console_init) | `$FEDB` | Video | Initialize console mode | none | r0 A P | X16
+| [`console_get_char`](#function-name-console_get_char) | `$FEE1` | Video | Get character from console | A | r0 r1 r2 r3 r4 r5 r6 r12 r13 r14 r15 A X Y P | X16
+| [`console_put_char`](#function-name-console_put_char) | `$FEDE` | Video | Print character to console | A C | r0 r1 r2 r3 r4 r5 r6 r12 r13 r14 r15 A X Y P | X16
+| [`console_put_image`](#function-name-console_put_image) | `$FED8` | Video | Draw image as if it was a character | r0 r1 r2 | r0 r1 r2 r3 r4 r5 r14 r15 A X Y P | X16
+| [`console_set_paging_message`](#function-name-console_set_paging_message) | `$FED5` | Video | Set paging message or disable paging | r0 | A P | X16
+| [`enter_basic`](#function-name-enter_basic) | `$FF47` | Misc | Enter BASIC | C | A X Y P | X16
+| [`entropy_get`](#function-name-entropy_get) | `$FECF` | Misc | get 24 random bits | none | A X Y P | X16
+| [`fetch`](#function-name-fetch) | `$FF74` | Mem | Read a byte from any RAM or ROM bank | (A) X Y | A X P | X16
+| [`FB_cursor_next_line`](#function-name-FB_cursor_next_line) &#8224; | `$FF02` | Video | Move direct-access cursor to next line | r0&#8224; | A P | X16
+| [`FB_cursor_position`](#function-name-FB_cursor_position) | `$FEFF` | Video | Position the direct-access cursor | r0 r1 | A P | X16
+| [`FB_fill_pixels`](#function-name-FB_fill_pixels) | `$FF17` | Video | Fill pixels with constant color, update cursor | r0 r1 A | A X Y P | X16
+| [`FB_filter_pixels`](#function-name-FB_filter_pixels) | `$FF1A` | Video | Apply transform to pixels, update cursor | r0 r1 | r14H r15 A X Y P | X16
+| [`FB_get_info`](#function-name-FB_get_info) | `$FEF9` | Video | Get screen size and color depth | none | r0 r1 A P | X16
+| [`FB_get_pixel`](#function-name-FB_get_pixel) | `$FF05` | Video | Read one pixel, update cursor | none | A | X16
+| [`FB_get_pixels`](#function-name-FB_get_pixels) | `$FF08` | Video | Copy pixels into RAM, update cursor | r0 r1 | (r0) A X Y P | X16
+| [`FB_init`](#function-name-FB_init) | `$FEF6` | Video | Enable graphics mode | none | A P | X16
+| [`FB_move_pixels`](#function-name-FB_move_pixels) | `$FF1D` | Video | Copy horizontally consecutive pixels to a different position | r0 r1 r2 r3 r4 | A X Y P | X16
+| [`FB_set_8_pixels`](#function-name-FB_set_8_pixels) | `$FF11` | Video | Set 8 pixels from bit mask (transparent), update cursor | A X | A P | X16
+| [`FB_set_8_pixels_opaque`](#function-name-FB_set_8_pixels_opaque) | `$FF14` | Video | Set 8 pixels from bit mask (opaque), update cursor | r0L A X Y| r0L A P | X16
+| [`FB_set_palette`](#function-name-FB_set_palette) &#128683; | `$FEFC` | Video | Set (parts of) the palette | - | - | X16
+| [`FB_set_pixel`](#function-name-FB_set_pixel) | `$FF0B` | Video | Set one pixel, update cursor | A | none | X16
+| [`FB_set_pixels`](#function-name-FB_set_pixels) | `$FF0E` | Video | Copy pixels from RAM, update cursor | r0 r1 | A X P | X16
 | `GETIN` | `$FFE4` | Kbd | Get character from keyboard | | | C64 |
+| [`GRAPH_clear`](#function-name-GRAPH_clear) | `$FF23` | Video | Clear screen | none | r0 r1 r2 r3 A X Y P | X16
+| [`GRAPH_draw_image`](#function-name-GRAPH_draw_image) | `$FF38` | Video | Draw a rectangular image | r0 r1 r2 r3 r4 | A P | X16
+| [`GRAPH_draw_line`](#function-name-GRAPH_draw_line) | `$FF2C` | Video | Draw a line | r0 r1 r2 r3 | r0 r1 r2 r3 r7 r8 r9 r10 r12 r13 A X Y P | X16
+| [`GRAPH_draw_oval`](#function-name-GRAPH_draw_oval) &#128683; | `$FF35` | Video | Draw an oval or circle | - | - | X16
+| [`GRAPH_draw_rect`](#function-name-GRAPH_draw_rect) | `$FF2F` | Video | Draw a rectangle (optionally filled) | r0 r1 r2 r3 r4 C | A P | X16
+| [`GRAPH_get_char_size`](#function-name-GRAPH_get_char_size) | `$FF3E` | Video | Get size and baseline of a character | A X | A X Y P | X16
+| [`GRAPH_init`](#function-name-GRAPH_init) | `$FF20` | Video | Initialize graphics | r0 | r0 r1 r2 r3 A X Y P | X16
+| [`GRAPH_move_rect`](#function-name-GRAPH_move_rect) | `$FF32` | Video | Move pixels | r0 r1 r2 r3 r4 r5 | r1 r3 r5 A X Y P | X16
+| [`GRAPH_put_char`](#function-name-GRAPH_put_char) | `$FF41` | Video | Print a character | r0 r1 A | r0 r1 A X Y P | X16
+| [`GRAPH_set_colors`](#function-name-GRAPH_set_colors) | `$FF29` | Video | Set stroke, fill and background colors | A X Y | none | X16
+| [`GRAPH_set_font`](#function-name-GRAPH_set_font) | `$FF3B` | Video | Set the current font | r0 | r0 A Y P | X16
+| [`GRAPH_set_window`](#function-name-GRAPH_set_window) | `$FF26` | Video | Set clipping region | r0 r1 r2 r3 | A P | X16
+| [`i2c_read_byte`](#function-name-i2c_read_byte) | `$FEC6` | I2C | Read a byte from an I2C device | A X Y | A C | X16
+| [`i2c_write_byte`](#function-name-i2c_write_byte) | `$FEC9` | I2C | Write a byte to an I2C device | A X Y | A C | X16
 | `IOBASE` | `$FFF3` | Misc | Return start of I/O area | | | C64 |
+| [`JSRFAR`](#function-name-JSRFAR) | `$FF6E` | Misc | Execute a routine on another RAM or ROM bank | PC+3 PC+5 | none | X16
+| [`joystick_get`](#function-name-joystick_get) | `$FF56` | Joy | Get one of the saved controller states | A | A X Y P | X16
+| [`joystick_scan`](#function-name-joystick_scan) | `$FF53` | Joy | Poll controller states and save them | none | A X Y P | X16
+| [`kbdbuf_get_modifiers`](#function-name-kbdbuf_get_modifiers) | `$FEC0` | Kbd | Get currently pressed modifiers | A | A X P | X16
+| [`kbdbuf_peek`](#function-name-kbdbuf_peek) | `$FEBD` | Kbd | Get next char and keyboard queue length | A X | A X P | X16
+| [`kbdbuf_put`](#function-name-kbdbuf_put) | `$FEC3` | Kbd | Append a character to the keyboard queue | A | X | X16
+| [`keymap`](#function-name-keymap) | `$FED2` | Kbd | Set or get the current keyboard layout Call address | X Y C | A X Y C | X16
 | `LISTEN` | `$FFB1` | CPB | Send LISTEN command | | | C64 |
 | `LKUPLA` | `$FF59` | ChIO | Search tables for given LA | | | C128 |
 | `LKUPSA` | `$FF5C` | ChIO | Search tables for given SA | | | C128 |
 | `LOAD` | `$FFD5` | ChIO | Load a file into memory | | | C64 |
 | `MACPTR` | `$FF44` | CPB | Read multiple bytes from the peripheral bus | A X Y C | A X Y P | X16
 | `MEMBOT` | `$FF9C` | Mem | Get address of start of usable RAM | | | C64 |
+| [`memory_copy`](#function-name-memory_copy) | `$FEE7` | Mem | Copy a memory region to a different region | r0 r1 r2 | r2 A X Y P | X16
+| [`memory_crc`](#function-name-memory_crc) | `$FEEA` | Mem | Calculate the CRC16 of a memory region | r0 r1 | r2 A X Y P | X16
+| [`memory_decompress`](#function-name-memory_decompress) | `$FEED` | Mem | Decompress an LZSA2 block | r0 r1 | r1 A X Y P | X16
+| [`memory_fill`](#function-name-memory_fill) | `$FEE4` | Mem | Fill a memory region with a byte value | A r0 r1 | r1 X Y P | X16
 | `MEMTOP` | `$FF99` | Mem | Get address of end of usable RAM | | | C64 |
+| [`monitor`](#function-name-monitor) | `$FF44` | Misc | Enter machine language monitor | none | A X Y P | X16
+| [`mouse_config`](#function-name-mouse_config) | `$FF68` | Mouse | Configure mouse pointer | A X Y | A X Y P | X16
+| [`mouse_get`](#function-name-mouse_get) | `$FF6B` | Mouse | Get saved mouse sate | X | A (X) P | X16
+| [`mouse_scan`](#function-name-mouse_scan) | `$FF71` | Mouse | Poll mouse state and save it | none | A X Y P | X16
 | `OPEN` | `$FFC0` | ChIO | Open a channel | | | C64 |
 | `PFKEY` | `$FF65` | Kbd | Program a function key *[not yet implemented]* | | | C128 |
 | `PLOT` | `$FFF0` | Video | Read/write cursor position | | | C64 |
@@ -51,76 +104,23 @@ The Commander X16 contains a version of KERNAL as its operating system in ROM. I
 | `READST` | `$FFB7` | ChIO | Return status byte | | | C64 |
 | `SAVE` | `$FFD8` | ChIO | Save a file from memory | | | C64 |
 | `SCREEN` | `$FFED` | Video | Get the screen resolution  | | | C64 |
+| [`screen_mode`](#function-name-screen_mode) | `$FF5F` | Video | Get/set screen mode | A C | A X Y P | X16
+| [`screen_set_charset`](#function-name-screen_set_charset) | `$FF62` | Video | Activate 8x8 text mode charset | A X Y | A X Y P | X16
 | `SECOND` | `$FF93` | CPB | Send LISTEN secondary address | | | C64 |
 | `SETLFS` | `$FFBA` | ChIO | Set LA, FA, and SA | | | C64 |
 | `SETMSG` | `$FF90` | ChIO | Set verbosity | | | C64 |
 | `SETNAM` | `$FFBD` | ChIO | Set filename | | | C64 |
 | `SETTIM` | `$FFDB` | Time | Write system clock | | | C64 |
 | `SETTMO` | `$FFA2` | CPB | Set timeout | | | C64 |
+| [`sprite_set_image`](#function-name-sprite_set_image) | `$FEF0` | Video | Set the image of a sprite | r0 r1 r2L A X Y C | A P | X16
+| [`sprite_set_position`](#function-name-sprite_set_position) | `$FEF3` | Video | Set the position of a sprite | r0 r1 A | A X P | X16
+| [`stash`](#function-name-stash) | `$FF77` | Mem | Write a byte to any RAM bank | stavec A X Y | (stavec) X P | X16
 | `STOP` | `$FFE1` | Kbd | Test for STOP key  | | | C64 |
 | `TALK` | `$FFB4` | CPB | Send TALK command  | | | C64 |
 | `TKSA` | `$FF96` | CPB | Send TALK secondary address | | | C64 |
 | `UDTIM` | `$FFEA` | Time | Advance clock | | | C64 |
 | `UNLSN` | `$FFAE` | CPB | Send UNLISTEN command | | | C64 |
 | `UNTLK` | `$FFAB` | CPB | Send UNTALK command | | | C64 |
-| [`clock_get_date_time`](#function-name-clock_get_date_time) | `$FF50` | Time | Get the date and time | none | r0 r1 r2 r3L A X Y P | X16
-| [`clock_set_date_time`](#function-name-clock_set_date_time) | `$FF4D` | Time | Set the date and time | r0 r1 r2 r3L | A X Y P | X16
-| [`fetch`](#function-name-fetch) | `$FF74` | Mem | Read a byte from any RAM or ROM bank | (A) X Y | A X P | X16
-| [`i2c_read_byte`](#function-name-i2c_read_byte) | `$FEC6` | I2C | Read a byte from an I2C device | A X Y | A C | X16
-| [`i2c_write_byte`](#function-name-i2c_write_byte) | `$FEC9` | I2C | Write a byte to an I2C device | A X Y | A C | X16
-| [`joystick_get`](#function-name-joystick_get) | `$FF56` | Joy | Get one of the saved controller states | A | A X Y P | X16
-| [`joystick_scan`](#function-name-joystick_scan) | `$FF53` | Joy | Poll controller states and save them | none | A X Y P | X16
-| [`kbdbuf_get_modifiers`](#function-name-kbdbuf_get_modifiers) | `$FEC0` | Kbd | Get currently pressed modifiers | A | A X P | X16
-| [`kbdbuf_peek`](#function-name-kbdbuf_peek) | `$FEBD` | Kbd | Get next char and keyboard queue length | A X | A X P | X16
-| [`kbdbuf_put`](#function-name-kbdbuf_put) | `$FEC3` | Kbd | Append a character to the keyboard queue | A | X | X16
-| [`keymap`](#function-name-keymap) | `$FED2` | Kbd | Set or get the current keyboard layout Call address | X Y C | A X Y C | X16
-| [`memory_copy`](#function-name-memory_copy) | `$FEE7` | Mem | Copy a memory region to a different region | r0 r1 r2 | r2 A X Y P | X16
-| [`memory_crc`](#function-name-memory_crc) | `$FEEA` | Mem | Calculate the CRC16 of a memory region | r0 r1 | r2 A X Y P | X16
-| [`memory_decompress`](#function-name-memory_decompress) | `$FEED` | Mem | Decompress an LZSA2 block | r0 r1 | r1 A X Y P | X16
-| [`memory_fill`](#function-name-memory_fill) | `$FEE4` | Mem | Fill a memory region with a byte value | A r0 r1 | r1 X Y P | X16
-| [`mouse_config`](#function-name-mouse_config) | `$FF68` | Mouse | Configure mouse pointer | A X Y | A X Y P | X16
-| [`mouse_scan`](#function-name-mouse_scan) | `$FF71` | Mouse | Poll mouse state and save it | none | A X Y P | X16
-| [`mouse_get`](#function-name-mouse_get) | `$FF6B` | Mouse | Get saved mouse sate | (X) | A P | X16
-| [`sprite_set_image`](#function-name-sprite_set_image) | `$FEF0` | Video | Set the image of a sprite | r0 r1 r2L A X Y C | A P | X16
-| [`sprite_set_position`](#function-name-sprite_set_position) | `$FEF3` | Video | Set the position of a sprite | r0 r1 A | A X P | X16
-| [`stash`](#function-name-stash) | `$FF77` | Mem | Write a byte to any RAM bank | stavec A X Y | X P | X16
-| [`FB_init`](#function-name-FB_init) | `$FEF6` | Video | Enable graphics mode
-| [`FB_get_info`](#function-name-FB_get_info) | `$FEF9` | Video | Get screen size and color depth
-| [`FB_set_palette`](#function-name-FB_set_palette) | `$FEFC` | Video | Set (parts of) the palette
-| [`FB_cursor_position`](#function-name-FB_cursor_position) | `$FEFF` | Video | Position the direct-access cursor
-| [`FB_cursor_next_line`](#function-name-FB_cursor_next_line) | `$FF02` | Video | Move direct-access cursor to next line
-| [`FB_get_pixel`](#function-name-FB_get_pixel) | `$FF05` | Video | Read one pixel, update cursor
-| [`FB_get_pixels`](#function-name-FB_get_pixels) | `$FF08` | Video | Copy pixels into RAM, update cursor
-| [`FB_set_pixel`](#function-name-FB_set_pixel) | `$FF0B` | Video | Set one pixel, update cursor
-| [`FB_set_pixels`](#function-name-FB_set_pixels) | `$FF0E` | Video | Copy pixels from RAM, update cursor
-| [`FB_set_8_pixels`](#function-name-FB_set_8_pixels) | `$FF11` | Video | Set 8 pixels from bit mask (transparent), update cursor
-| [`FB_set_8_pixels_opaque`](#function-name-FB_set_8_pixels_opaque) | `$FF14` | Video | Set 8 pixels from bit mask (opaque), update cursor
-| [`FB_fill_pixels`](#function-name-FB_fill_pixels) | `$FF17` | Video | Fill pixels with constant color, update cursor
-| [`FB_filter_pixels`](#function-name-FB_filter_pixels) | `$FF1A` | Video | Apply transform to pixels, update cursor
-| [`FB_move_pixels`](#function-name-FB_move_pixels) | `$FF1D` | Video | Copy horizontally consecutive pixels to a different position
-| [`GRAPH_init`](#function-name-GRAPH_init) | `$FF20` | Video | Initialize graphics
-| [`GRAPH_clear`](#function-name-GRAPH_clear) | `$FF23` | Video | Clear screen
-| [`GRAPH_set_window`](#function-name-GRAPH_set_window) | `$FF26` | Video | Set clipping region
-| [`GRAPH_set_colors`](#function-name-GRAPH_set_colors) | `$FF29` | Video | Set stroke, fill and background colors
-| [`GRAPH_draw_line`](#function-name-GRAPH_draw_line) | `$FF2C` | Video | Draw a line
-| [`GRAPH_draw_rect`](#function-name-GRAPH_draw_rect) | `$FF2F` | Video | Draw a rectangle (optionally filled)
-| [`GRAPH_move_rect`](#function-name-GRAPH_move_rect) | `$FF32` | Video | Move pixels
-| [`GRAPH_draw_oval`](#function-name-GRAPH_draw_oval) | `$FF35` | Video | Draw an oval or circle
-| [`GRAPH_draw_image`](#function-name-GRAPH_draw_image) | `$FF38` | Video | Draw a rectangular image
-| [`GRAPH_set_font`](#function-name-GRAPH_set_font) | `$FF3B` | Video | Set the current font
-| [`GRAPH_get_char_size`](#function-name-GRAPH_get_char_size) | `$FF3E` | Video | Get size and baseline of a character
-| [`GRAPH_put_char`](#function-name-GRAPH_put_char) | `$FF41` | Video | Print a character
-| [`console_init`](#function-name-console_init) | `$FEDB` | Video | Initialize console mode
-| [`console_put_char`](#function-name-console_put_char) | `$FEDE` | Video | Print character to console
-| [`console_put_image`](#function-name-console_put_image) | `$FED8` | Video | Draw image as if it was a character
-| [`console_get_char`](#function-name-console_get_char) | `$FEE1` | Video | Get character from console
-| [`console_set_paging_message`](#function-name-console_set_paging_message) | `$FED5` | Video | Set paging message or disable paging
-| [`entropy_get`](#function-name-entropy_get) | `$FECF` | Misc | get 24 random bits
-| [`monitor`](#function-name-monitor) | `$FF44` | Misc | Enter machine language monitor
-| [`enter_basic`](#function-name-enter_basic) | `$FF47` | Misc | Enter BASIC
-| [`screen_mode`](#function-name-screen_mode) | `$FF5F` | Video | Get/set screen mode
-| [`screen_set_charset`](#function-name-screen_set_charset) | `$FF62` | Video | Activate 8x8 text mode charset
-| [`JSRFAR`](#function-name-JSRFAR) | `$FF6E` | Misc | Execute a routine on another RAM or ROM bank
 
 
 ### KERNAL Version

--- a/X16 Reference - 04 - KERNAL.md
+++ b/X16 Reference - 04 - KERNAL.md
@@ -25,66 +25,102 @@ The Commander X16 contains a version of KERNAL as its operating system in ROM. I
 
 | Label | Address | Class | Description | Inputs | Affects | Origin |
 |-|-|-|-|-|-|-|
-| `SETMSG` | `$FF90` | ChIO | Set verbosity | | | C64 |
-| `READST` | `$FFB7` | ChIO | Return status byte | | | C64 |
-| `SETLFS` | `$FFBA` | ChIO | Set LA, FA, and SA | | | C64 |
-| `SETNAM` | `$FFBD` | ChIO | Set filename | | | C64 |
-| `OPEN` | `$FFC0` | ChIO | Open a channel | | | C64 |
-| `CLOSE` | `$FFC3` | ChIO | Close a channel | | | C64 |
-| `CHKIN` | `$FFC6` | ChIO | Set channel for character input | | | C64 |
-| `CLRCHN` | `$FFCC` | ChIO | Restore character I/O to screen/keyboard | | | C64 |
+| `ACPTR` | `$FFA5` | CPB | Read byte from peripheral bus | | | C64 |
 | `BASIN` | `$FFCF` | ChIO | Get character | | | C64 |
 | `BSOUT` | `$FFD2` | ChIO | Write character | | | C64 |
-| `LOAD` | `$FFD5` | ChIO | Load a file into memory | | | C64 |
-| `SAVE` | `$FFD8` | ChIO | Save a file from memory | | | C64 |
-| `CLALL` | `$FFE7` | ChIO | Close all channels | | | C64 |
-| `TALK` | `$FFB4` | CPB | Send TALK command  | | | C64 |
-| `LISTEN` | `$FFB1` | CPB | Send LISTEN command | | | C64 |
-| `UNLSN` | `$FFAE` | CPB | Send UNLISTEN command | | | C64 |
-| `UNTLK` | `$FFAB` | CPB | Send UNTALK command | | | C64 |
 | `CIOUT` | `$FFA8` | CPB | Send byte to peripheral bus | | | C64 |  
-| `ACPTR` | `$FFA5` | CPB | Read byte from peripheral bus | | | C64 |
-| `SETTMO` | `$FFA2` | CPB | Set timeout | | | C64 |
-| `TKSA` | `$FF96` | CPB | Send TALK secondary address | | | C64 |
-| `SECOND` | `$FF93` | CPB | Send LISTEN secondary address | | | C64 |
-| `MEMBOT` | `$FF9C` | Mem | Get address of start of usable RAM | | | C64 |
-| `MEMTOP` | `$FF99` | Mem | Get address of end of usable RAM | | | C64 |
-| `RDTIM` | `$FFDE` | Time | Read system clock | | | C64 |
-| `SETTIM` | `$FFDB` | Time | Write system clock | | | C64 |
-| `UDTIM` | `$FFEA` | Time | Advance clock | | | C64 |
-| `STOP` | `$FFE1` | Kbd | Test for STOP key  | | | C64 |
-| `GETIN` | `$FFE4` | Kbd | Get character from keyboard | | | C64 |
-| `SCREEN` | `$FFED` | Video | Get the screen resolution  | | | C64 |
-| `PLOT` | `$FFF0` | Video | Read/write cursor position | | | C64 |
-| `IOBASE` | `$FFF3` | Misc | Return start of I/O area | | | C64 |
+| `CLALL` | `$FFE7` | ChIO | Close all channels | | | C64 |
+| `CLOSE` | `$FFC3` | ChIO | Close a channel | | | C64 |
+| `CHKIN` | `$FFC6` | ChIO | Set channel for character input | | | C64 |
 | `CLOSE_ALL` | `$FF4A` | ChIO | Close all files on a device  | | | C128 |
+| `CLRCHN` | `$FFCC` | ChIO | Restore character I/O to screen/keyboard | | | C64 |
+| `GETIN` | `$FFE4` | Kbd | Get character from keyboard | | | C64 |
+| `IOBASE` | `$FFF3` | Misc | Return start of I/O area | | | C64 |
+| `LISTEN` | `$FFB1` | CPB | Send LISTEN command | | | C64 |
 | `LKUPLA` | `$FF59` | ChIO | Search tables for given LA | | | C128 |
 | `LKUPSA` | `$FF5C` | ChIO | Search tables for given SA | | | C128 |
-| `PFKEY` | `$FF65` | Kbd | Program a function key *[not yet implemented]* | | | C128 |
-| `PRIMM` | `$FF7D` | Misc | Print string following the caller’s code | | | C128 |
+| `LOAD` | `$FFD5` | ChIO | Load a file into memory | | | C64 |
 | `MACPTR` | `$FF44` | CPB | Read multiple bytes from the peripheral bus | A X Y C | A X Y P | X16
-| [`memory_fill`](#function-name-memory_fill) | `$FEE4` | Mem | Fill a memory region with a byte value | A r0 r1 | r1 X Y P | X16
+| `MEMBOT` | `$FF9C` | Mem | Get address of start of usable RAM | | | C64 |
+| `MEMTOP` | `$FF99` | Mem | Get address of end of usable RAM | | | C64 |
+| `OPEN` | `$FFC0` | ChIO | Open a channel | | | C64 |
+| `PFKEY` | `$FF65` | Kbd | Program a function key *[not yet implemented]* | | | C128 |
+| `PLOT` | `$FFF0` | Video | Read/write cursor position | | | C64 |
+| `PRIMM` | `$FF7D` | Misc | Print string following the caller’s code | | | C128 |
+| `RDTIM` | `$FFDE` | Time | Read system clock | | | C64 |
+| `READST` | `$FFB7` | ChIO | Return status byte | | | C64 |
+| `SAVE` | `$FFD8` | ChIO | Save a file from memory | | | C64 |
+| `SCREEN` | `$FFED` | Video | Get the screen resolution  | | | C64 |
+| `SECOND` | `$FF93` | CPB | Send LISTEN secondary address | | | C64 |
+| `SETLFS` | `$FFBA` | ChIO | Set LA, FA, and SA | | | C64 |
+| `SETMSG` | `$FF90` | ChIO | Set verbosity | | | C64 |
+| `SETNAM` | `$FFBD` | ChIO | Set filename | | | C64 |
+| `SETTIM` | `$FFDB` | Time | Write system clock | | | C64 |
+| `SETTMO` | `$FFA2` | CPB | Set timeout | | | C64 |
+| `STOP` | `$FFE1` | Kbd | Test for STOP key  | | | C64 |
+| `TALK` | `$FFB4` | CPB | Send TALK command  | | | C64 |
+| `TKSA` | `$FF96` | CPB | Send TALK secondary address | | | C64 |
+| `UDTIM` | `$FFEA` | Time | Advance clock | | | C64 |
+| `UNLSN` | `$FFAE` | CPB | Send UNLISTEN command | | | C64 |
+| `UNTLK` | `$FFAB` | CPB | Send UNTALK command | | | C64 |
+| [`clock_get_date_time`](#function-name-clock_get_date_time) | `$FF50` | Time | Get the date and time | none | r0 r1 r2 r3L A X Y P | X16
+| [`clock_set_date_time`](#function-name-clock_set_date_time) | `$FF4D` | Time | Set the date and time | r0 r1 r2 r3L | A X Y P | X16
+| [`fetch`](#function-name-fetch) | `$FF74` | Mem | Read a byte from any RAM or ROM bank | (A) X Y | A X P | X16
+| [`i2c_read_byte`](#function-name-i2c_read_byte) | `$FEC6` | I2C | Read a byte from an I2C device | A X Y | A C | X16
+| [`i2c_write_byte`](#function-name-i2c_write_byte) | `$FEC9` | I2C | Write a byte to an I2C device | A X Y | A C | X16
+| [`joystick_get`](#function-name-joystick_get) | `$FF56` | Joy | Get one of the saved controller states | A | A X Y P | X16
+| [`joystick_scan`](#function-name-joystick_scan) | `$FF53` | Joy | Poll controller states and save them | none | A X Y P | X16
+| [`kbdbuf_get_modifiers`](#function-name-kbdbuf_get_modifiers) | `$FEC0` | Kbd | Get currently pressed modifiers | A | A X P | X16
+| [`kbdbuf_peek`](#function-name-kbdbuf_peek) | `$FEBD` | Kbd | Get next char and keyboard queue length | A X | A X P | X16
+| [`kbdbuf_put`](#function-name-kbdbuf_put) | `$FEC3` | Kbd | Append a character to the keyboard queue | A | X | X16
+| [`keymap`](#function-name-keymap) | `$FED2` | Kbd | Set or get the current keyboard layout Call address | X Y C | A X Y C | X16
 | [`memory_copy`](#function-name-memory_copy) | `$FEE7` | Mem | Copy a memory region to a different region | r0 r1 r2 | r2 A X Y P | X16
 | [`memory_crc`](#function-name-memory_crc) | `$FEEA` | Mem | Calculate the CRC16 of a memory region | r0 r1 | r2 A X Y P | X16
 | [`memory_decompress`](#function-name-memory_decompress) | `$FEED` | Mem | Decompress an LZSA2 block | r0 r1 | r1 A X Y P | X16
-| [`fetch`](#function-name-fetch) | `$FF74` | Mem | Read a byte from any RAM or ROM bank | (A) X Y | A X P | X16
-| [`stash`](#function-name-stash) | `$FF77` | Mem | Write a byte to any RAM bank | stavec A X Y | X P | X16
-| [`clock_set_date_time`](#function-name-clock_set_date_time) | `$FF4D` | Time | Set the date and time | r0 r1 r2 r3L | A X Y P | X16
-| [`clock_get_date_time`](#function-name-clock_get_date_time) | `$FF50` | Time | Get the date and time | none | r0 r1 r2 r3L A X Y P | X16
-| [`kbdbuf_peek`](#function-name-kbdbuf_peek) | `$FEBD` | Kbd | Get next char and keyboard queue length | A X | A X P | X16
-| [`kbdbuf_get_modifiers`](#function-name-kbdbuf_get_modifiers) | `$FEC0` | Kbd | Get currently pressed modifiers | A | A X P | X16
-| [`kbdbuf_put`](#function-name-kbdbuf_put) | `$FEC3` | Kbd | Append a character to the keyboard queue | A | X | X16
-| [`keymap`](#function-name-keymap) | `$FED2` | Kbd | Set or get the current keyboard layout Call address | X Y C | A X Y C | X16
+| [`memory_fill`](#function-name-memory_fill) | `$FEE4` | Mem | Fill a memory region with a byte value | A r0 r1 | r1 X Y P | X16
 | [`mouse_config`](#function-name-mouse_config) | `$FF68` | Mouse | Configure mouse pointer | A X Y | A X Y P | X16
 | [`mouse_scan`](#function-name-mouse_scan) | `$FF71` | Mouse | Poll mouse state and save it | none | A X Y P | X16
 | [`mouse_get`](#function-name-mouse_get) | `$FF6B` | Mouse | Get saved mouse sate | (X) | A P | X16
-| [`joystick_scan`](#function-name-joystick_scan) | `$FF53` | Joy | Poll controller states and save them | none | A X Y P | X16
-| [`joystick_get`](#function-name-joystick_get) | `$FF56` | Joy | Get one of the saved controller states | A | A X Y P | X16
-| [`i2c_read_byte`](#function-name-i2c_read_byte) | `$FEC6` | I2C | Read a byte from an I2C device | A X Y | A C | X16
-| [`i2c_write_byte`](#function-name-i2c_write_byte) | `$FEC9` | I2C | Write a byte to an I2C device | A X Y | A C | X16
-
-
-
+| [`sprite_set_image`](#function-name-sprite_set_image) | `$FEF0` | Video | Set the image of a sprite | r0 r1 r2L A X Y C | A P | X16
+| [`sprite_set_position`](#function-name-sprite_set_position) | `$FEF3` | Video | Set the position of a sprite | r0 r1 A | A X P | X16
+| [`stash`](#function-name-stash) | `$FF77` | Mem | Write a byte to any RAM bank | stavec A X Y | X P | X16
+| [`FB_init`](#function-name-FB_init) | `$FEF6` | Video | Enable graphics mode
+| [`FB_get_info`](#function-name-FB_get_info) | `$FEF9` | Video | Get screen size and color depth
+| [`FB_set_palette`](#function-name-FB_set_palette) | `$FEFC` | Video | Set (parts of) the palette
+| [`FB_cursor_position`](#function-name-FB_cursor_position) | `$FEFF` | Video | Position the direct-access cursor
+| [`FB_cursor_next_line`](#function-name-FB_cursor_next_line) | `$FF02` | Video | Move direct-access cursor to next line
+| [`FB_get_pixel`](#function-name-FB_get_pixel) | `$FF05` | Video | Read one pixel, update cursor
+| [`FB_get_pixels`](#function-name-FB_get_pixels) | `$FF08` | Video | Copy pixels into RAM, update cursor
+| [`FB_set_pixel`](#function-name-FB_set_pixel) | `$FF0B` | Video | Set one pixel, update cursor
+| [`FB_set_pixels`](#function-name-FB_set_pixels) | `$FF0E` | Video | Copy pixels from RAM, update cursor
+| [`FB_set_8_pixels`](#function-name-FB_set_8_pixels) | `$FF11` | Video | Set 8 pixels from bit mask (transparent), update cursor
+| [`FB_set_8_pixels_opaque`](#function-name-FB_set_8_pixels_opaque) | `$FF14` | Video | Set 8 pixels from bit mask (opaque), update cursor
+| [`FB_fill_pixels`](#function-name-FB_fill_pixels) | `$FF17` | Video | Fill pixels with constant color, update cursor
+| [`FB_filter_pixels`](#function-name-FB_filter_pixels) | `$FF1A` | Video | Apply transform to pixels, update cursor
+| [`FB_move_pixels`](#function-name-FB_move_pixels) | `$FF1D` | Video | Copy horizontally consecutive pixels to a different position
+| [`GRAPH_init`](#function-name-GRAPH_init) | `$FF20` | Video | Initialize graphics
+| [`GRAPH_clear`](#function-name-GRAPH_clear) | `$FF23` | Video | Clear screen
+| [`GRAPH_set_window`](#function-name-GRAPH_set_window) | `$FF26` | Video | Set clipping region
+| [`GRAPH_set_colors`](#function-name-GRAPH_set_colors) | `$FF29` | Video | Set stroke, fill and background colors
+| [`GRAPH_draw_line`](#function-name-GRAPH_draw_line) | `$FF2C` | Video | Draw a line
+| [`GRAPH_draw_rect`](#function-name-GRAPH_draw_rect) | `$FF2F` | Video | Draw a rectangle (optionally filled)
+| [`GRAPH_move_rect`](#function-name-GRAPH_move_rect) | `$FF32` | Video | Move pixels
+| [`GRAPH_draw_oval`](#function-name-GRAPH_draw_oval) | `$FF35` | Video | Draw an oval or circle
+| [`GRAPH_draw_image`](#function-name-GRAPH_draw_image) | `$FF38` | Video | Draw a rectangular image
+| [`GRAPH_set_font`](#function-name-GRAPH_set_font) | `$FF3B` | Video | Set the current font
+| [`GRAPH_get_char_size`](#function-name-GRAPH_get_char_size) | `$FF3E` | Video | Get size and baseline of a character
+| [`GRAPH_put_char`](#function-name-GRAPH_put_char) | `$FF41` | Video | Print a character
+| [`console_init`](#function-name-console_init) | `$FEDB` | Video | Initialize console mode
+| [`console_put_char`](#function-name-console_put_char) | `$FEDE` | Video | Print character to console
+| [`console_put_image`](#function-name-console_put_image) | `$FED8` | Video | Draw image as if it was a character
+| [`console_get_char`](#function-name-console_get_char) | `$FEE1` | Video | Get character from console
+| [`console_set_paging_message`](#function-name-console_set_paging_message) | `$FED5` | Video | Set paging message or disable paging
+| [`entropy_get`](#function-name-entropy_get) | `$FECF` | Misc | get 24 random bits
+| [`monitor`](#function-name-monitor) | `$FF44` | Misc | Enter machine language monitor
+| [`enter_basic`](#function-name-enter_basic) | `$FF47` | Misc | Enter BASIC
+| [`screen_mode`](#function-name-screen_mode) | `$FF5F` | Video | Get/set screen mode
+| [`screen_set_charset`](#function-name-screen_set_charset) | `$FF62` | Video | Activate 8x8 text mode charset
+| [`JSRFAR`](#function-name-JSRFAR) | `$FF6E` | Misc | Execute a routine on another RAM or ROM bank
 
 
 ### KERNAL Version

--- a/X16 Reference - 04 - KERNAL.md
+++ b/X16 Reference - 04 - KERNAL.md
@@ -48,8 +48,8 @@ The following C128 APIs have equivalent functionality on the X16 but are not com
 
 | Address | C128 Name | X16 Name             |
 |---------|-----------|----------------------|
-| $FF5F   | `SWAPPER` | [`screen_mode`](#function-name-screenmode) |
-| $FF62   | `DLCHR`   | [`screen_set_charset`](#function-name-screensetcharset) |
+| $FF5F   | `SWAPPER` | [`screen_mode`](#function-name-screen_mode) |
+| $FF62   | `DLCHR`   | [`screen_set_charset`](#function-name-screen_set_charset) |
 | $FF74   | `FETCH`   | [`fetch`](#function-name-fetch) |
 | $FF77   | `STASH`   | [`stash`](#function-name-stash) |
 <!---
@@ -172,7 +172,7 @@ The 16 bit ABI generally follows the following conventions:
 | `SETNAM` | `$FFBD` | ChIO | Set filename | | | C64 |
 | `SETTIM` | `$FFDB` | Time | Write system clock | | | C64 |
 | `SETTMO` | `$FFA2` | CPB | Set timeout | | | C64 |
-| [`sprite_set_image`](#function-name-sprite_set_image) | `$FEF0` | Video | Set the image of a sprite | r0 r1 r2L A X Y C | A P | X16
+| [`sprite_set_image`](#function-name-sprite_set_image) &#8224; | `$FEF0` | Video | Set the image of a sprite | r0 r1 r2L A X Y C | A P | X16
 | [`sprite_set_position`](#function-name-sprite_set_position) | `$FEF3` | Video | Set the position of a sprite | r0 r1 A | A X P | X16
 | [`stash`](#function-name-stash) | `$FF77` | Mem | Write a byte to any RAM bank | stavec A X Y | (stavec) X P | X16
 | `STOP` | `$FFE1` | Kbd | Test for STOP key  | | | C64 |


### PR DESCRIPTION
I got some positive feedback from when I shared this as a work-in-progress.  We still need to include documentation for the C64 and C128 API, but I think this is a good start.

This also indicates the two completely unimplemented calls that are otherwise documented.