### PR TITLE
Updated MACPTR reference

### DIFF
--- a/X16 Reference - 04 - KERNAL.md
+++ b/X16 Reference - 04 - KERNAL.md
@@ -223,7 +223,7 @@ $FF44: `MACPTR` - read multiple bytes from peripheral bus
 
 Purpose: Read multiple bytes from the peripheral bus  
 Call address: $FF44  
-Communication registers: .A, .X, .Y  
+Communication registers: .A, .X, .Y, .C  
 Preparatory routines: `FILNAM`, `FILPAR`, `OPEN`, `CHKIN`  
 Error returns: None  
 Stack requirements: ...  
@@ -231,7 +231,9 @@ Registers affected: .A, .X, .Y
 
 **Description:** The routine `MACPTR` is the multi-byte variant of the `ACPTR` KERNAL routine. Instead of returning a single byte in .A, it can read multiple bytes in one call and write them directly to memory.
 
-The number of bytes to be read is passed in the .A register; a value of 0 indicates that it is up to the KERNAL to decide how many bytes to read. A pointer to where the data is supposed to be written is passed in the .X (lo) and .Y (hi) registers.
+The number of bytes to be read is passed in the .A register; a value of 0 indicates that it is up to the KERNAL to decide how many bytes to read. A pointer to where the data is supposed to be written is passed in the .X (lo) and .Y (hi) registers. If carry flag is clear, the destination address will advance with each byte read. If the carry flag is set, the destination address will not advance as data is read. This is useful for reading data directly into VRAM, PCM FIFO, etc.
+
+For reading into Hi RAM, you must set the desired bank prior to calling MACPTR. During the read, MACPTR will automatically wrap to the next bank as required, leaving the new bank active when finished.
 
 Upon return, a set .C flag indicates that the device does not support `MACPTR`, and the program needs to read the data byte-by-byte using the `ACPTR` call instead.
 


### PR DESCRIPTION
Added information regarding the new C flag calling convention for MACPTR and added info regarding the routine's behavior when reading into banked RAM.