### PR TITLE
Programmers guide in pdf and MS Word formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+release/*

--- a/X16 Reference - 02 - Editor.md
+++ b/X16 Reference - 02 - Editor.md
@@ -179,7 +179,7 @@ On boot, the US layout (`ABC/X16`) is active:
 | Shift+Alt+`b`     | ²      |
 | Shift+Alt+`/`     | ¿      |
 
-(The X16 logo is code point \xad, SHY, soft-hyphen.)
+(The X16 logo is code point \\xad, SHY, soft-hyphen.)
 
 The following combinations are dead keys:
 

--- a/X16 Reference - 09 - Sound Programming.md
+++ b/X16 Reference - 09 - Sound Programming.md
@@ -458,9 +458,9 @@ Range|Type|Description
   </tr>
 </table>
 
-## YM2151 Register Details
+### YM2151 Register Details
 
-### Global Parameters:
+#### Global Parameters:
 
 **LR** (LFO Reset)
 
@@ -581,7 +581,7 @@ Register $1B, Bits 0-1
 Sets the LFO waveform:
 0: Sawtooth, 1: Square (50% duty cycle), 2: Triangle, 3: Noise
 
-### Channel Control Parameters:
+#### Channel Control Parameters:
 
 **RL** (Right/Left output enable)
 
@@ -647,7 +647,7 @@ Sensitivity values: (dB)
 -|-|-|-
 0|23.90625|47.8125|95.625
 
-### Operator Control Parameters:
+#### Operator Control Parameters:
 
 Operators are arranged as follows:
 

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+pandoc --version || {
+    echo Install the following commands:
+    echo sudo apt install pandoc texlive texlive-xetex
+}
+mkdir -p release
+rm -f programmers-guide.md
+echo Generating pdf...
+find . -iname "X16 *.md" -print0 | sort --zero-terminated \
+    | xargs -0 pandoc --file-scope    --pdf-engine=xelatex -o release/programmers-guide.pdf
+echo Generating docfile...
+find . -iname "X16 *.md" -print0 | sort --zero-terminated \
+    | xargs -0 pandoc --file-scope   -o release/programmers-guide.docx


### PR DESCRIPTION
Hi, I have done a small script to genate pdf & word version of the Programmers Guide for reference and printing.

Feel free to review the idea and ask for fix or modifications.
I was forced to modify some lines to get it processed by pandoc.
Also, I demoted "YM2151 Register Details" to get it as a sub-chapter.

