### PR TITLE
Add cartridge memory

### DIFF
--- a/X16 Reference - 07 - Memory Map.md
+++ b/X16 Reference - 07 - Memory Map.md
@@ -2,8 +2,7 @@
 
 The Commander X16 has 512 KB of ROM and 2,088 KB (2 MB[^1] + 40 KB) of RAM with up to 3.5MB of RAM or ROM available to cartridges.
 
-Some of the ROM and RAM is always visible at certain address ranges, while the remaining ROM and RAM is banked into one of two address windows. 
-Banked cartridge RAM/ROM is also available.
+Some of the ROM/RAM is always visible at certain address ranges, while the remaining ROM/RAM is banked into one of two address windows. 
 
 This is an overview of the X16 memory map:
 
@@ -12,7 +11,7 @@ This is an overview of the X16 memory map:
 |$0000-$9EFF|Fixed RAM (40 KB minus 256 bytes)						                                |
 |$9F00-$9FFF|I/O Area (256 bytes)										                            |
 |$A000-$BFFF|Banked RAM (8 KB window into one of 256 banks for a total of 2 MB)                     |
-|$C000-$FFFF|Banked System ROM and Catridge ROM/RAM (16 KB window into one of 255 banks, see below) |
+|$C000-$FFFF|Banked System ROM and Cartridge ROM/RAM (16 KB window into one of 255 banks, see below) |
 
 ### Banked Memory
 
@@ -42,6 +41,11 @@ This is the allocation of the banks of banked ROM/Cartridge:
 |8     |GRAPH  |Kernal graph and font routines                         |
 |9-31  |–      |*[Currently unused]*                                   |
 |32-255|–      | Cartridge RAM/ROM                                     |
+
+#### Cartridge Allocation
+
+Cartridges can use the remaining 32-255 banks in any combination of ROM, RAM, Memory-Mapped IO, etc. See Kevin's reference cartridge design
+for ideas on how this may be used.
 
 **Important**: The layout of the banks is not yet final.
 

--- a/X16 Reference - 07 - Memory Map.md
+++ b/X16 Reference - 07 - Memory Map.md
@@ -1,45 +1,49 @@
 ## Chapter 7: Memory Map
 
-The Commander X16 has 64 KB of ROM and 2,088 KB (2 MB[^1] + 40 KB) of RAM. Some of the ROM and RAM is always visible at certain address ranges, while the remaining ROM and RAM is banked into one of two address windows.
+The Commander X16 has 512 KB of ROM and 2,088 KB (2 MB[^1] + 40 KB) of RAM with up to 3.5MB of RAM or ROM available to cartridges.
+
+Some of the ROM and RAM is always visible at certain address ranges, while the remaining ROM and RAM is banked into one of two address windows. 
+Banked cartridge RAM/ROM is also available.
 
 This is an overview of the X16 memory map:
 
-|Addresses  |Description                                                       |
-|-----------|------------------------------------------------------------------|
-|$0000-$9EFF|Fixed RAM (40 KB minus 256 bytes)								   |
-|$9F00-$9FFF|I/O Area (256 bytes)											   |
-|$A000-$BFFF|Banked RAM (8 KB window into one of 256 banks for a total of 2 MB)|
-|$C000-$FFFF|Banked ROM (16 KB window into one of 32 banks for a total of 512 KB) |
+|Addresses  |Description                                                                            |
+|-----------|---------------------------------------------------------------------------------------|
+|$0000-$9EFF|Fixed RAM (40 KB minus 256 bytes)						                                |
+|$9F00-$9FFF|I/O Area (256 bytes)										                            |
+|$A000-$BFFF|Banked RAM (8 KB window into one of 256 banks for a total of 2 MB)                     |
+|$C000-$FFFF|Banked System ROM and Catridge ROM/RAM (16 KB window into one of 255 banks, see below) |
 
 ### Banked Memory
 
 The currently enabled RAM and ROM banks can be configured by writing to zero page locations 0 and 1:
 
-|Address  |Description              |
-|---------|-------------------------|
-|$0000    |Current RAM bank (0-255) |
-|$0001    |Current ROM bank (0-31)  |
+|Address  |Description                                                   |
+|---------|--------------------------------------------------------------|
+|$0000    |Current RAM bank (0-255)                                      |
+|$0001    |Current ROM/Cartridge bank (ROM is 0-31, Cartridge is 32-255) |
 
 The currently set banks can also be read back from the respective memory locations. Both settings default to 0 on RESET. The upper three bits of location 1 are undefined.
 
 ### ROM Allocations
 
-This is the allocation of the banks of banked ROM:
+This is the allocation of the banks of banked ROM/Cartridge:
 
-|Bank|Name   |Description                                            |
-|----|-------|-------------------------------------------------------|
-|0   |KERNAL |KERNAL operating system and drivers                    |
-|1   |KEYBD  |Keyboard layout tables                                 |
-|2   |CBDOS  |The computer-based CBM-DOS for FAT32 SD cards          |
-|3   |GEOS   |GEOS KERNAL                                            |
-|4   |BASIC  |BASIC interpreter                                      |
-|5   |MONITOR|Machine Language Monitor                               |
-|6   |CHARSET|PETSCII and ISO character sets (uploaded into VRAM)    |
-|7   |CODEX  |CodeX16 Interactive Assembly Environment / Monitor     |
-|8   |GRAPH  |Kernal graph and font routines                         |
-|9-31|–      |*[Currently unused]*                                   |
+|Bank  |Name   |Description                                            |
+|------|-------|-------------------------------------------------------|
+|0     |KERNAL |KERNAL operating system and drivers                    |
+|1     |KEYBD  |Keyboard layout tables                                 |
+|2     |CBDOS  |The computer-based CBM-DOS for FAT32 SD cards          |
+|3     |GEOS   |GEOS KERNAL                                            |
+|4     |BASIC  |BASIC interpreter                                      |
+|5     |MONITOR|Machine Language Monitor                               |
+|6     |CHARSET|PETSCII and ISO character sets (uploaded into VRAM)    |
+|7     |CODEX  |CodeX16 Interactive Assembly Environment / Monitor     |
+|8     |GRAPH  |Kernal graph and font routines                         |
+|9-31  |–      |*[Currently unused]*                                   |
+|32-255|–      | Cartridge RAM/ROM                                     |
 
-**Important**: The layout of the banks is still constantly changing.
+**Important**: The layout of the banks is not yet final.
 
 ### RAM Contents
 
@@ -53,7 +57,7 @@ This is the allocation of fixed RAM in the KERNAL/BASIC environment.
 |$0400-$07FF|Available for machine code programs or custom data storage      |
 |$0800-$9EFF|BASIC program/variables; available to the user                  |
 
-The $0400-$07FF can be seen as the equivalent of $C000-$CFFF on a C64. A typical use would be for helper machine code called by BASIC.
+The `$0400-$07FF` can be seen as the equivalent of `$C000-$CFFF` on a C64. A typical use would be for helper machine code called by BASIC.
 
 #### Zero Page
 
@@ -69,7 +73,7 @@ The $0400-$07FF can be seen as the equivalent of $C000-$CFFF on a C64. A typical
 
 Machine code applications are free to reuse the BASIC area, and if they don't use the Math library, also that area.
 
-#### Banking
+#### RAM Banking
 
 This is the allocation of banked RAM in the KERNAL/BASIC environment.
 


### PR DESCRIPTION
Docs were missing cartridge usage and memory map.