### PR TITLE
Fix addresses for SYS arguments

### DIFF
--- a/X16 Reference - 03 - BASIC.md
+++ b/X16 Reference - 03 - BASIC.md
@@ -22,10 +22,10 @@ The Commander X16 BASIC interpreter is 100% backwards-compatible with the Commod
 	* `CHR$(142)`: switch to uppercase/graphics font
 * The BASIC vector table ($0300-0$30B, $0311/$0312)
 * SYS arguments in RAM ($030C-$030F).
-	* `$030C`: X Register
-	* `$030D`: Y Register
-	* `$030E`: Status Register/Flags
-	* `$030F`: Accumulator
+	* `$030C`: Accumulator
+	* `$030D`: X Register
+	* `$030E`: Y Register
+	* `$030F`: Status Register/Flags
 
 Because of the differences in hardware, the following functions and statements are incompatible between C64 and X16 BASIC programs.
 


### PR DESCRIPTION
These were added in #83, but seem to be incorrect.

Changing to the addresses found using emulator from release 41, which also seem to correlate with memory maps for C64.